### PR TITLE
Better exceptions management

### DIFF
--- a/src/test/test_exceptions.py
+++ b/src/test/test_exceptions.py
@@ -1,0 +1,28 @@
+"""
+Unit test about exception management.
+
+"""
+import unittest
+
+from .. import asp
+
+
+class TestGringo4Clasp(unittest.TestCase):
+
+    def test_gringo_error(self):
+        gringo = asp.Gringo4()
+        with self.assertRaises(OSError):
+            gringo.run([], additionalProgramText='..')
+
+    def test_clasp_error(self):
+        clasp = asp.Clasp()
+        with self.assertRaises(OSError):
+            clasp.run([], additionalProgramText='..')
+
+    def test_clasp_error(self):
+        solver = asp.Gringo4Clasp()
+        answer = next(iter(solver.run([], additionalProgramText='a:- not b. b:- not a.')))
+        self.assertEqual(answer.__class__, asp.TermSet)
+        with self.assertRaises(TypeError):  # try to hash the TermSet
+            set([answer])
+


### PR DESCRIPTION
Pyasp raise many exceptions, and some of them are just _Exception_.
The aim of this PR is to fix that by using proper exception subclass, and to improve printings of gringo/clasp stderr messages.

The TermSet.__hash__ redefinition is removed, as the mother class (set) already rise the standard exception. (as shown by unit test)
